### PR TITLE
Add the ability to start at a certian block.

### DIFF
--- a/BlockExplorer.vue
+++ b/BlockExplorer.vue
@@ -37,6 +37,12 @@ const headers = {Accept: 'application/ld+json, application/json'};
 export default {
   name: 'BlockExplorer',
   components: {Blocks},
+  props: {
+    startBlock: {
+      type: Number,
+      default: null
+    }
+  },
   data() {
     return {
       loading: true,
@@ -46,7 +52,6 @@ export default {
       blockCache: {},
       blockIdBase: null,
       latestBlockHeight: 0,
-      startBlock: 0,
       ledgerBlockService: null
     };
   },
@@ -70,7 +75,8 @@ export default {
 
     this.latestBlockHeight = latestBlock.block.blockHeight + 1;
     this.ledgerBlockService = ledgerAgent.service.ledgerBlockService;
-    this.startBlock = this.latestBlockHeight;
+    this.startBlock = this.startBlock === null ?
+      this.latestBlockHeight : this.startBlock;
     clearTimeout(showLoadingId);
     this.loading = false;
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # bedrock-vue-web-ledger ChangeLog
 
+## 0.1.1 -
+- Make start-block configurable
+
 ## 0.1.0 - 2019-09-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # bedrock-vue-web-ledger ChangeLog
 
-## 0.1.1 -
+## 0.2.0 -
 - Make start-block configurable
 
 ## 0.1.0 - 2019-09-06


### PR DESCRIPTION
Adds the ability to pass in a new prop `start-block` that if set means the Ledger Explorer starts at that block else the Explorer starts at the last block.