### PR TITLE
Replace axios http client

### DIFF
--- a/BlockExplorer.vue
+++ b/BlockExplorer.vue
@@ -28,8 +28,6 @@
 import {httpClient} from '@digitalbazaar/http-client';
 import Blocks from './Blocks.vue';
 
-const headers = {Accept: 'application/ld+json, application/json'};
-
 export default {
   name: 'BlockExplorer',
   components: {Blocks},
@@ -53,7 +51,7 @@ export default {
   },
   async mounted() {
     const showLoadingId = setTimeout(() => this.showLoading = true, 1000);
-    const laResponse = await httpClient.get('/ledger-agents/', {headers});
+    const laResponse = await httpClient.get('/ledger-agents/');
     // FIXME: Don't assume there is only one ledger agent
     const ledgerAgent = laResponse.data.ledgerAgent[0];
     const bsResponse =

--- a/BlockExplorer.vue
+++ b/BlockExplorer.vue
@@ -25,7 +25,7 @@
  */
 'use strict';
 
-import axios from 'axios';
+import {httpClient} from '@digitalbazaar/http-client';
 import Blocks from './Blocks.vue';
 
 const headers = {Accept: 'application/ld+json, application/json'};
@@ -53,11 +53,11 @@ export default {
   },
   async mounted() {
     const showLoadingId = setTimeout(() => this.showLoading = true, 1000);
-    const laResponse = await axios.get('/ledger-agents/', {headers});
+    const laResponse = await httpClient.get('/ledger-agents/', {headers});
     // FIXME: Don't assume there is only one ledger agent
     const ledgerAgent = laResponse.data.ledgerAgent[0];
     const bsResponse =
-      await axios.get(ledgerAgent.service.ledgerBlockService);
+      await httpClient.get(ledgerAgent.service.ledgerBlockService);
 
     const genesisBlock = bsResponse.data.genesis;
     this.blockCache[genesisBlock.block.id] = genesisBlock;

--- a/BlockExplorer.vue
+++ b/BlockExplorer.vue
@@ -58,7 +58,6 @@ export default {
     const ledgerAgent = laResponse.data.ledgerAgent[0];
     const bsResponse =
       await httpClient.get(ledgerAgent.service.ledgerBlockService);
-
     const genesisBlock = bsResponse.data.genesis;
     this.blockCache[genesisBlock.block.id] = genesisBlock;
 

--- a/Blocks.vue
+++ b/Blocks.vue
@@ -57,7 +57,7 @@
  */
 'use strict';
 
-import axios from 'axios';
+import {httpClient} from '@digitalbazaar/http-client';
 
 export default {
   name: 'Blocks',
@@ -104,7 +104,7 @@ export default {
     async getCurrentBlock() {
       const fetchBlockId = this.makeBlockId(this.currentBlock - 1);
       if(!(fetchBlockId in this.blockCache)) {
-        const block = await axios.get(this.ledgerBlockService, {
+        const block = await httpClient.get(this.ledgerBlockService, {
           params: {
             id: fetchBlockId
           }

--- a/Blocks.vue
+++ b/Blocks.vue
@@ -105,7 +105,7 @@ export default {
       const fetchBlockId = this.makeBlockId(this.currentBlock - 1);
       if(!(fetchBlockId in this.blockCache)) {
         const block = await httpClient.get(this.ledgerBlockService, {
-          params: {
+          searchParams: {
             id: fetchBlockId
           }
         });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vue-web-ledger ChangeLog
 
+## 0.4.0 - TBD
+
+### Changed
+- **BREAKING:** Remove `axios` in favor of `@digitalbazaar/http-client`.
+
 ## 0.3.1 - 2020-04-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "homepage": "https://github.com/digitalbazaar/bedrock-vue-web-ledger",
   "devDependencies": {
-    "eslint": "^6.3.0",
-    "eslint-config-digitalbazaar": "^2.0.1",
-    "eslint-plugin-vue": "^5.2.2"
+    "eslint": "^8.0.1",
+    "eslint-config-digitalbazaar": "^2.8.0",
+    "eslint-plugin-vue": "^7.20.0"
   },
   "dependencies": {
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-vue": "^7.20.0"
   },
   "dependencies": {
-    "axios": "^0.19.0",
+    "@digitalbazaar/http-client": "^1.2.0",
     "vue-json-tree-view": "^2.1.4"
   },
   "scripts": {


### PR DESCRIPTION
Replaces `axios` with `http-client`. I marked this as a major release. Feel free to disagree.